### PR TITLE
Hook SavedItem.Get instead of CollectableItemPickup.DoPickupAction and fix names

### DIFF
--- a/GUI/VibeSettings/VibeSources/BuzzOnPickups.cs
+++ b/GUI/VibeSettings/VibeSources/BuzzOnPickups.cs
@@ -1,4 +1,4 @@
-﻿using ButtplugSong.GUI.VibeSettings.Presets;
+using ButtplugSong.GUI.VibeSettings.Presets;
 using ButtplugSong.Helper;
 using System.Collections.Generic;
 using UnityEngine.UIElements;
@@ -213,13 +213,15 @@ internal class BuzzOnPickups : VibeSourceWithPunctuate
     }
     private void OnSetInt(string intName, int value)
     {
+        if (KnownItems.ContainsKey(intName)) Log($"SET INT MATCH: {intName} = {value}");
         TryActivate(intName);
     }
     private void OnSetBool(string boolName, bool value)
     {
+        if (value && KnownItems.ContainsKey(boolName)) Log($"SET BOOL MATCH: {boolName}");
         if (value) TryActivate(boolName);
     }
-    private void ItemPickup(SavedItem item, CollectableItemPickup instance)
+    private void ItemPickup(SavedItem item)
     {
         Log($"GOT ITEM: {item.GetType().Name} - {item.name} (unique: {item.IsUnique})");
         TryActivate(item.name);

--- a/ModHooks.cs
+++ b/ModHooks.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using System;
 using UnityEngine;
 
@@ -82,15 +82,19 @@ internal static class ModHooks
         OnGetCocoonHook?.Invoke(__instance);
     }
 
-    //Item pickup
-    public static event Action<SavedItem, CollectableItemPickup>? OnItemPickupHook;
-    [HarmonyPatch(typeof(CollectableItemPickup), nameof(CollectableItemPickup.DoPickupAction))]
+    //Item pickup (hooks SavedItem.Get to catch both world pickups AND shop purchases)
+    public static event Action<SavedItem>? OnItemPickupHook;
+    [HarmonyPatch(typeof(SavedItem), nameof(SavedItem.Get), typeof(int), typeof(bool))]
     [HarmonyPrefix]
-    private static void OnItemPickup(CollectableItemPickup __instance, bool breakIfAtMax)
+    private static void OnItemGet(SavedItem __instance, int amount, bool showPopup)
     {
-        var item = __instance.item;
-        if (item == null) return;
-        OnItemPickupHook?.Invoke(item, __instance);
+        OnItemPickupHook?.Invoke(__instance);
+    }
+    [HarmonyPatch(typeof(SavedItem), nameof(SavedItem.Get), typeof(bool))]
+    [HarmonyPrefix]
+    private static void OnItemGetSimple(SavedItem __instance, bool showPopup)
+    {
+        OnItemPickupHook?.Invoke(__instance);
     }
 
     public static event Action<string, bool>? OnSetBoolHook;


### PR DESCRIPTION
This fixes items from both world pickups AND shop purchases. Previously, shop items did not trigger buzz events.