### PR TITLE
Fix silent mask shard / spool fragment pickups

### DIFF
--- a/GUI/VibeSettings/VibeSources/BuzzOnPickups.cs
+++ b/GUI/VibeSettings/VibeSources/BuzzOnPickups.cs
@@ -20,6 +20,8 @@ internal class BuzzOnPickups : VibeSourceWithPunctuate
         ModHooks.OnSetIntHook += OnSetInt;
         ModHooks.OnMaxHealthUpHook += OnMaxHealthUp;
         ModHooks.OnMaxSilkUpHook += OnMaxSilkUp;
+        ModHooks.OnHeartPieceCollectedHook += OnHeartPieceCollected;
+        ModHooks.OnSpoolFragmentCollectedHook += OnSpoolFragmentCollected;
         ModHooks.OnToolUnlockHook += ToolUnlock;
 
         _scaleWithWeighting = Get<Toggle>("PickupsScaleWithWeighting");
@@ -245,4 +247,6 @@ internal class BuzzOnPickups : VibeSourceWithPunctuate
     }
     private void OnMaxHealthUp() => TryActivate("fullHeart");
     private void OnMaxSilkUp() => TryActivate("fullSpool");
+    private void OnHeartPieceCollected() => TryActivate("heartPieces");
+    private void OnSpoolFragmentCollected() => TryActivate("silkSpoolParts");
 }

--- a/ModHooks.cs
+++ b/ModHooks.cs
@@ -187,6 +187,23 @@ internal static class ModHooks
         OnMaxSilkUpHook?.Invoke();
     }
 
+    // Individual shard/fragment collection (heartPieces/silkSpoolParts are plain fields, bypass SetInt)
+    public static event Action? OnHeartPieceCollectedHook;
+    [HarmonyPatch(typeof(GameManager), nameof(GameManager.CheckHeartAchievements))]
+    [HarmonyPostfix]
+    private static void OnHeartPieceCollected()
+    {
+        OnHeartPieceCollectedHook?.Invoke();
+    }
+
+    public static event Action? OnSpoolFragmentCollectedHook;
+    [HarmonyPatch(typeof(GameManager), nameof(GameManager.CheckSilkSpoolAchievements))]
+    [HarmonyPostfix]
+    private static void OnSpoolFragmentCollected()
+    {
+        OnSpoolFragmentCollectedHook?.Invoke();
+    }
+
     public static event Action<ToolItem>? OnToolUnlockHook;
     [HarmonyPatch(typeof(ToolItem), nameof(ToolItem.Unlock))]
     [HarmonyPostfix]

--- a/ModHooks.cs
+++ b/ModHooks.cs
@@ -202,11 +202,16 @@ internal static class ModHooks
 
         static IEnumerable<MethodBase> TargetMethods()
         {
+            var log = BepInEx.Logging.Logger.CreateLogSource("ButtplugSong.Hooks");
             var methods = new List<MethodBase>();
 
             var baseGet = typeof(SavedItem).GetMethod(nameof(SavedItem.Get), new[] { typeof(int), typeof(bool) });
             if (baseGet != null && !baseGet.IsAbstract)
                 methods.Add(baseGet);
+
+            var baseGetSimple = typeof(SavedItem).GetMethod(nameof(SavedItem.Get), new[] { typeof(bool) });
+            if (baseGetSimple != null && !baseGetSimple.IsAbstract)
+                methods.Add(baseGetSimple);
 
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
@@ -227,6 +232,10 @@ internal static class ModHooks
                     }
                 }
             }
+
+            foreach (var m in methods)
+                log.LogInfo($"SavedItemGetPatch target: {m.DeclaringType.Name}.{m.Name}({string.Join(", ", m.GetParameters().Select(p => p.ParameterType.Name))})");
+
             return methods;
         }
 


### PR DESCRIPTION
 Currently, the mask shards and spool fragments pickups don't fire haptics. The game writes heartPieces / silkSpoolParts via PlayerData.IncrementInt, which sets the field directly via reflection and bypasses SetInt, so OnSetIntHook never fires.
  
GameManager.CheckHeartAchievements and CheckSilkSpoolAchievements run after every pickup, so postfixing them catches each one.
  
  - Add OnHeartPieceCollectedHook + postfix on CheckHeartAchievements
  - Add OnSpoolFragmentCollectedHook + postfix on CheckSilkSpoolAchievements
  - BuzzOnPickups routes both to existing KnownItems entries
  
  Also adds SavedItem.Get(bool) to SavedItemGetPatch so certain CollectableItemBasic items (Memory Lockets, some shop items) fire too.
