### PR TITLE
Pr/playerdata bypass coverage

### DIFF
--- a/ButtplugSongPlugin.cs
+++ b/ButtplugSongPlugin.cs
@@ -24,6 +24,7 @@ namespace ButtplugSong
             vibe = new VibeManager(ModPath, Logger.LogInfo);
 
             harmony.PatchAll();
+            ModHooks.ApplySetVariablePatch(harmony);
 
             Logger.LogInfo($"Plugin {Name} ({Id}) has loaded!");
         }

--- a/ButtplugSongPlugin.cs
+++ b/ButtplugSongPlugin.cs
@@ -25,6 +25,7 @@ namespace ButtplugSong
 
             harmony.PatchAll();
             ModHooks.ApplySetVariablePatch(harmony);
+            PlayerDataPoller.EnsureExists();
 
             Logger.LogInfo($"Plugin {Name} ({Id}) has loaded!");
         }

--- a/GUI/VibeSettings/VibeSources/BuzzOnPickups.cs
+++ b/GUI/VibeSettings/VibeSources/BuzzOnPickups.cs
@@ -151,7 +151,6 @@ internal class BuzzOnPickups : VibeSourceWithPunctuate
             "Magnetite Dice", "Scuttlebrace", "Bone Necklace", "Shell Satchel",
             "Sprintmaster", "Musician Charm", "Thief Charm", "Weighted Anklet");
 
-        //Need to be fixed
         KnownItems["ToolPouchUpgrades"] = CreateUI("ToolPouch", 0.5f, true);
         KnownItems["Tool Pouch&Kit Inv"] = KnownItems["ToolPouchUpgrades"];
         KnownItems["ToolKitUpgrades"] = CreateUI("CraftingKit", 0.5f, true, true);
@@ -162,7 +161,6 @@ internal class BuzzOnPickups : VibeSourceWithPunctuate
         KnownItems["fullHeart"] = CreateUI("FullMask", 1f, true);
         KnownItems["silkSpoolParts"] = CreateUI("SpoolFragment", 0.4f, true);
         KnownItems["fullSpool"] = CreateUI("FullSpool", 0.6f, true, true);
-        // end of to be fixed
         #endregion
 
         #region Navigation / World

--- a/GUI/VibeSettings/VibeSources/BuzzOnPickups.cs
+++ b/GUI/VibeSettings/VibeSources/BuzzOnPickups.cs
@@ -12,6 +12,8 @@ internal class BuzzOnPickups : VibeSourceWithPunctuate
 
     private readonly Dictionary<string, WeightedEvent> KnownItems = new();
     private readonly Dictionary<string, object> _lastValues = new();
+    private string _lastPickupName = "";
+    private float _lastPickupTime;
     protected override string _punctuateReminderDescription => "collecting an item";
 
     public BuzzOnPickups() : base("Pickups", false, 50, 5, true)
@@ -23,6 +25,50 @@ internal class BuzzOnPickups : VibeSourceWithPunctuate
         ModHooks.OnMaxSilkUpHook += OnMaxSilkUp;
         ModHooks.OnToolUnlockHook += ToolUnlock;
         ModHooks.OnPlayerDataSetVariableHook += OnPlayerDataSetVariable;
+
+        // Start poller for PD fields that bypass SetBool/SetInt (shop purchases, direct writes)
+        var poller = PlayerDataPoller.EnsureExists();
+        // Bool PD fields to poll
+        foreach (var f in new[] {
+            // Maps
+            "HasBellhartMap", "HasSwampMap", "HasJudgeStepsMap", "HasHallsMap", "HasCogMap",
+            "HasCradleMap", "HasDocksMap", "HasWildsMap", "HasSongGateMap", "HasGreymoorMap",
+            "HasHangMap", "HasHuntersNestMap", "HasArboriumMap", "HasMossGrottoMap", "HasPeakMap",
+            "HasAqueductMap", "HasCoralMap", "HasShellwoodMap", "HasDustpensMap", "HasAbyssMap",
+            "HasBoneforestMap", "HasSlabMap", "HasCitadelUnderstoreMap", "HasCloverMap",
+            "HasWeavehomeMap", "HasLibraryMap", "HasWardMap", "HasCrawlMap",
+            // Markers & pins
+            "hasMarker_a", "hasMarker_b", "hasMarker_c", "hasMarker_d", "hasMarker_e",
+            "hasPinBench", "hasPinStag", "hasPinShop", "hasPinTube",
+            "hasPinFleaMarrowlands", "hasPinFleaMidlands", "hasPinFleaBlastedlands",
+            "hasPinFleaCitadel", "hasPinFleaPeaklands", "hasPinFleaMucklands",
+            // Silk skill PD bools
+            "hasParry", "hasSilkBossNeedle", "hasSilkBomb", "hasSilkCharge",
+            "hasNeedleThrow", "hasThreadSphere",
+            // Abilities
+            "hasDash", "hasWalljump", "hasHarpoonDash", "hasSuperJump", "hasChargeSlash",
+            "hasBrolly", "hasDoubleJump", "hasNeedolin", "hasNeedolinMemoryPowerup",
+            "UnlockedFastTravelTeleport", "HasMelodyArchitect", "HasMelodyConductor",
+            "HasMelodyLibrarian", "HasBoundCrestUpgrader",
+            // Vesticrest
+            "UnlockedExtraBlueSlot", "UnlockedExtraYellowSlot",
+            // Bellway stations
+            "UnlockedDocksStation", "UnlockedBoneforestEastStation", "UnlockedGreymoorStation",
+            "UnlockedBelltownStation", "UnlockedCoralTowerStation", "UnlockedCityStation",
+            "UnlockedPeakStation", "UnlockedShellwoodStation", "UnlockedShadowStation",
+            "UnlockedAqueductStation",
+            // Ventrica stations
+            "UnlockedSongTube", "UnlockedUnderTube", "UnlockedCityBellwayTube",
+            "UnlockedHangTube", "UnlockedEnclaveTube", "UnlockedArboriumTube",
+            // Bellhome
+            "BelltownFurnishingDesk", "BelltownFurnishingFairyLights",
+            "BelltownFurnishingGramaphone", "BelltownFurnishingSpa"
+        }) poller.TrackBool(f);
+        // Int PD fields to poll
+        foreach (var f in new[] { "heartPieces", "silkSpoolParts", "silkRegenMax", "QuillState", "ToolPouchUpgrades", "ToolKitUpgrades" })
+            poller.TrackInt(f);
+        // CollectableItemManager-based items (Amount tracking, not PlayerData)
+        poller.TrackCollectable("Mossberry");
 
         _scaleWithWeighting = Get<Toggle>("PickupsScaleWithWeighting");
         _scaleWithWeighting.SetupSaving(true).DependsOn(_enabled);
@@ -75,7 +121,8 @@ internal class BuzzOnPickups : VibeSourceWithPunctuate
             "Courier Supplies Slave", "Song Pilgrim Cloak", "Fine Pin", "Pilgrim Rag",
             "Plasmium Blood", "Plasmium", "Crow Feather", "Roach Corpse Item",
             "Enemy Morsel Seared", "Enemy Morsel Shredded", "Silver Bellclapper",
-            "Enemy Morsel Speared", "Common Spine", "Flintgem");
+            "Enemy Morsel Speared", "Common Spine", "Flintgem",
+            "Conchfly Remains", "Blue Goop Jar", "Coral Chunk", "Shining Cog");
 
         MapCategory(CreateUI("Mementos", 1, true, true),
             "Crowman Memento", "Grey Memento", "Memento Seth",
@@ -104,6 +151,7 @@ internal class BuzzOnPickups : VibeSourceWithPunctuate
             "Magnetite Dice", "Scuttlebrace", "Bone Necklace", "Shell Satchel",
             "Sprintmaster", "Musician Charm", "Thief Charm", "Weighted Anklet");
 
+        //Need to be fixed
         KnownItems["ToolPouchUpgrades"] = CreateUI("ToolPouch", 0.5f, true);
         KnownItems["Tool Pouch&Kit Inv"] = KnownItems["ToolPouchUpgrades"];
         KnownItems["ToolKitUpgrades"] = CreateUI("CraftingKit", 0.5f, true, true);
@@ -114,7 +162,7 @@ internal class BuzzOnPickups : VibeSourceWithPunctuate
         KnownItems["fullHeart"] = CreateUI("FullMask", 1f, true);
         KnownItems["silkSpoolParts"] = CreateUI("SpoolFragment", 0.4f, true);
         KnownItems["fullSpool"] = CreateUI("FullSpool", 0.6f, true, true);
-
+        // end of to be fixed
         #endregion
 
         #region Navigation / World
@@ -158,8 +206,12 @@ internal class BuzzOnPickups : VibeSourceWithPunctuate
 
         #region Abilities
 
-        MapCategory(CreateUI("SilkSkills", 1, true, categoryLabel: "Abilities"),
-            "Parry", "Silk Boss Needle", "Silk Bomb", "Silk Charge", "Silk Spear", "Thread Sphere");
+        var silkSkillsUI = CreateUI("SilkSkills", 1, true, categoryLabel: "Abilities");
+        MapCategory(silkSkillsUI,
+            "Parry", "Silk Boss Needle", "Silk Bomb", "Silk Charge", "Silk Spear", "Thread Sphere",
+            // PD bools for silk skills (polled):
+            "hasParry", "hasSilkBossNeedle", "hasSilkBomb", "hasSilkCharge",
+            "hasNeedleThrow", "hasThreadSphere");
 
         KnownItems["hasDash"] = CreateUI("SwiftStep", 0.6f, true);
         KnownItems["hasWalljump"] = CreateUI("ClingGrip", 1.2f, true);
@@ -234,7 +286,15 @@ internal class BuzzOnPickups : VibeSourceWithPunctuate
     {
         Log($"GOT ITEM: {item.GetType().Name} - {item.name} (unique: {item.IsUnique})");
         if (item is ToolItem) return; // Handled by OnToolUnlockHook
+        // Dedup: Get() and Collect() both fire for same pickup
+        float now = UnityEngine.Time.unscaledTime;
+        if (item.name == _lastPickupName && now - _lastPickupTime < 0.5f) return;
+        _lastPickupName = item.name;
+        _lastPickupTime = now;
+        // item.name uses underscores (Unity asset name), KnownItems uses spaces
         TryActivate(item.name);
+        var spaceName = item.name.Replace("_", " ");
+        if (spaceName != item.name) TryActivate(spaceName);
     }
     private void ToolUnlock(ToolItem tool)
     {

--- a/GUI/VibeSettings/VibeSources/BuzzOnPickups.cs
+++ b/GUI/VibeSettings/VibeSources/BuzzOnPickups.cs
@@ -11,6 +11,7 @@ internal class BuzzOnPickups : VibeSourceWithPunctuate
     public bool ScaleWithWeighting { get => _scaleWithWeighting.value; set => _scaleWithWeighting.value = value; }
 
     private readonly Dictionary<string, WeightedEvent> KnownItems = new();
+    private readonly Dictionary<string, object> _lastValues = new();
     protected override string _punctuateReminderDescription => "collecting an item";
 
     public BuzzOnPickups() : base("Pickups", false, 50, 5, true)
@@ -21,6 +22,7 @@ internal class BuzzOnPickups : VibeSourceWithPunctuate
         ModHooks.OnMaxHealthUpHook += OnMaxHealthUp;
         ModHooks.OnMaxSilkUpHook += OnMaxSilkUp;
         ModHooks.OnToolUnlockHook += ToolUnlock;
+        ModHooks.OnPlayerDataSetVariableHook += OnPlayerDataSetVariable;
 
         _scaleWithWeighting = Get<Toggle>("PickupsScaleWithWeighting");
         _scaleWithWeighting.SetupSaving(true).DependsOn(_enabled);
@@ -214,17 +216,24 @@ internal class BuzzOnPickups : VibeSourceWithPunctuate
     }
     private void OnSetInt(string intName, int value)
     {
-        Log($"[DIAG] SetInt: {intName} = {value}{(KnownItems.ContainsKey(intName) ? " *** MATCH ***" : "")}");
+        if (!KnownItems.ContainsKey(intName)) return;
+        if (_lastValues.TryGetValue(intName, out var prev) && prev is int prevInt && value <= prevInt) return;
+        _lastValues[intName] = value;
+        Log($"SET INT CHANGED: {intName} = {value}");
         TryActivate(intName);
     }
     private void OnSetBool(string boolName, bool value)
     {
-        if (value) Log($"[DIAG] SetBool: {boolName} = true{(KnownItems.ContainsKey(boolName) ? " *** MATCH ***" : "")}");
-        if (value) TryActivate(boolName);
+        if (!value || !KnownItems.ContainsKey(boolName)) return;
+        if (_lastValues.TryGetValue(boolName, out var prev) && prev is bool prevBool && prevBool) return;
+        _lastValues[boolName] = value;
+        Log($"SET BOOL CHANGED: {boolName} = true");
+        TryActivate(boolName);
     }
     private void ItemPickup(SavedItem item)
     {
         Log($"GOT ITEM: {item.GetType().Name} - {item.name} (unique: {item.IsUnique})");
+        if (item is ToolItem) return; // Handled by OnToolUnlockHook
         TryActivate(item.name);
     }
     private void ToolUnlock(ToolItem tool)
@@ -245,4 +254,19 @@ internal class BuzzOnPickups : VibeSourceWithPunctuate
     }
     private void OnMaxHealthUp() => TryActivate("fullHeart");
     private void OnMaxSilkUp() => TryActivate("fullSpool");
+    private void OnHeartPieceCollected() => TryActivate("heartPieces");
+    private void OnSpoolFragmentCollected() => TryActivate("silkSpoolParts");
+    private void OnPlayerDataSetVariable(string fieldName, object value)
+    {
+        if (!KnownItems.ContainsKey(fieldName)) return;
+        // Diff against snapshot — only trigger on actual change
+        if (_lastValues.TryGetValue(fieldName, out var prev))
+        {
+            if (value is bool curBool && prev is bool prevBool && curBool == prevBool) return;
+            if (value is int curInt && prev is int prevInt && curInt <= prevInt) return;
+        }
+        _lastValues[fieldName] = value;
+        Log($"PD SETVAR CHANGED: {fieldName} = {value}");
+        TryActivate(fieldName);
+    }
 }

--- a/Helper/PlayerDataPoller.cs
+++ b/Helper/PlayerDataPoller.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+
+namespace ButtplugSong;
+
+/// <summary>
+/// Polls tracked PlayerData fields via reflection to detect direct field writes
+/// that bypass SetBool/SetInt (e.g., shop purchases, map acquisitions).
+/// Fires OnSetBoolHook/OnSetIntHook when changes are detected.
+/// </summary>
+internal class PlayerDataPoller : MonoBehaviour
+{
+    private static PlayerDataPoller? _instance;
+    private static readonly BepInEx.Logging.ManualLogSource _log =
+        BepInEx.Logging.Logger.CreateLogSource("ButtplugSong.Poller");
+
+    private readonly Dictionary<string, object> _snapshot = new();
+    private readonly HashSet<string> _trackedBools = new();
+    private readonly HashSet<string> _trackedInts = new();
+    private readonly HashSet<string> _trackedCollectables = new();
+    private readonly Dictionary<string, int> _collectableSnapshot = new();
+
+    private const float PollIntervalSeconds = 0.5f;
+
+    public static PlayerDataPoller EnsureExists()
+    {
+        if (_instance != null) return _instance;
+        var go = new GameObject("ButtplugSong_PDPoller");
+        DontDestroyOnLoad(go);
+        _instance = go.AddComponent<PlayerDataPoller>();
+        _log.LogInfo("PlayerData poller started.");
+        return _instance;
+    }
+
+    public void TrackBool(string fieldName)
+    {
+        _trackedBools.Add(fieldName);
+    }
+
+    public void TrackInt(string fieldName)
+    {
+        _trackedInts.Add(fieldName);
+    }
+
+    /// <summary>
+    /// Track a CollectableItemManager item by name (e.g. "Mossberry").
+    /// When its Amount increases, fires OnSetIntHook with the collectable name.
+    /// </summary>
+    public void TrackCollectable(string collectableName)
+    {
+        _trackedCollectables.Add(collectableName);
+    }
+
+    private void Start()
+    {
+        StartCoroutine(PollLoop());
+    }
+
+    private IEnumerator PollLoop()
+    {
+        // Wait for game to fully load
+        yield return new WaitForSeconds(2f);
+
+        while (true)
+        {
+            yield return new WaitForSeconds(PollIntervalSeconds);
+
+            if (!PlayerData.HasInstance) continue;
+            var pd = PlayerData.instance;
+            var pdType = pd.GetType();
+
+            foreach (var fieldName in _trackedBools)
+            {
+                try
+                {
+                    object? raw = GetMemberValue(pdType, pd, fieldName);
+                    if (raw == null) continue;
+
+                    bool current = (bool)raw;
+                    bool prev = false;
+                    if (_snapshot.TryGetValue(fieldName, out var prevObj) && prevObj is bool pb)
+                        prev = pb;
+
+                    if (current != prev)
+                    {
+                        _snapshot[fieldName] = current;
+                        if (current) // Only trigger on false -> true
+                        {
+                            _log.LogInfo($"POLL BOOL CHANGED: {fieldName} = {current}");
+                            ModHooks.RaiseSetBool(fieldName, current);
+                        }
+                    }
+                }
+                catch { /* member doesn't exist on this PD version, skip */ }
+            }
+
+            foreach (var fieldName in _trackedInts)
+            {
+                try
+                {
+                    object? raw = GetMemberValue(pdType, pd, fieldName);
+                    if (raw == null) continue;
+
+                    int current = (int)raw;
+                    int prev = 0;
+                    if (_snapshot.TryGetValue(fieldName, out var prevObj) && prevObj is int pi)
+                        prev = pi;
+
+                    if (current != prev)
+                    {
+                        int prevVal = prev;
+                        _snapshot[fieldName] = current;
+                        if (current > prevVal) // Only trigger on increase
+                        {
+                            _log.LogInfo($"POLL INT CHANGED: {fieldName} = {current} (was {prevVal})");
+                            ModHooks.RaiseSetInt(fieldName, current);
+                        }
+                    }
+                }
+                catch { /* member doesn't exist on this PD version, skip */ }
+            }
+
+            // Poll CollectableItemManager for tracked collectables (e.g. Mossberry)
+            if (_trackedCollectables.Count > 0)
+            {
+                try
+                {
+                    var mgrType = typeof(CollectableItemManager);
+                    var instanceProp = mgrType.GetProperty("Instance", BindingFlags.Static | BindingFlags.Public);
+                    var mgr = instanceProp?.GetValue(null);
+                    if (mgr != null)
+                    {
+                        // Find all SavedItem children (CollectableItemBasic, etc.)
+                        // and compare their .name to tracked names
+                        var getAllMethod = mgrType.GetMethod("GetAllCollectables", BindingFlags.Instance | BindingFlags.Public)
+                                       ?? mgrType.GetMethod("GetAllItems", BindingFlags.Instance | BindingFlags.Public);
+                        if (getAllMethod != null)
+                        {
+                            var items = getAllMethod.Invoke(mgr, null) as System.Collections.IEnumerable;
+                            if (items != null)
+                            {
+                                foreach (var item in items)
+                                {
+                                    if (item is SavedItem si && _trackedCollectables.Contains(si.name))
+                                    {
+                                        // Try to get amount via reflection (CollectableItemBasic stores it differently)
+                                        int amount = 0;
+                                        var amtProp = si.GetType().GetProperty("Amount", BindingFlags.Instance | BindingFlags.Public);
+                                        if (amtProp != null)
+                                            amount = (int)amtProp.GetValue(si);
+                                        else
+                                        {
+                                            var amtField = si.GetType().GetField("Amount", BindingFlags.Instance | BindingFlags.Public);
+                                            if (amtField != null)
+                                                amount = (int)amtField.GetValue(si);
+                                        }
+
+                                        int prev = -1;
+                                        if (_collectableSnapshot.TryGetValue(si.name, out var p))
+                                            prev = p;
+
+                                        if (amount != prev)
+                                        {
+                                            _collectableSnapshot[si.name] = amount;
+                                            if (prev >= 0 && amount > prev) // skip initial snapshot
+                                            {
+                                                _log.LogInfo($"POLL COLLECTABLE: {si.name} = {amount} (was {prev})");
+                                                ModHooks.RaiseSetInt(si.name, amount);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex) { _log.LogDebug($"Collectable poll error: {ex.Message}"); }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Resets the snapshot (call when loading a new save to avoid false positives from stale data).
+    /// </summary>
+    public void ResetSnapshot()
+    {
+        _snapshot.Clear();
+        _collectableSnapshot.Clear();
+        _log.LogInfo("Snapshot reset.");
+    }
+
+    /// <summary>
+    /// Gets a value from PlayerData by trying field first, then property.
+    /// PlayerDataAccess uses C# properties, not raw fields.
+    /// </summary>
+    private static object? GetMemberValue(Type type, object instance, string name)
+    {
+        var field = type.GetField(name, BindingFlags.Instance | BindingFlags.Public);
+        if (field != null) return field.GetValue(instance);
+
+        var prop = type.GetProperty(name, BindingFlags.Instance | BindingFlags.Public);
+        if (prop != null) return prop.GetValue(instance);
+
+        return null;
+    }
+}

--- a/Helper/PlayerDataPoller.cs
+++ b/Helper/PlayerDataPoller.cs
@@ -204,18 +204,25 @@ internal class PlayerDataPoller : MonoBehaviour
         _log.LogInfo("Snapshot reset.");
     }
 
-    /// <summary>
-    /// Gets a value from PlayerData by trying field first, then property.
-    /// PlayerDataAccess uses C# properties, not raw fields.
-    /// </summary>
+    // Resolved-once-then-cached MemberInfo per field name. Each entry is either
+    // FieldInfo, PropertyInfo, or null sentinel meaning "no such member, do not look again."
+    // Bounds the per-poll reflection to a single dictionary lookup after warmup.
+    private static readonly Dictionary<string, MemberInfo?> _memberCache = new();
+    private static readonly object _missingSentinel = new();
+
     private static object? GetMemberValue(Type type, object instance, string name)
     {
-        var field = type.GetField(name, BindingFlags.Instance | BindingFlags.Public);
-        if (field != null) return field.GetValue(instance);
-
-        var prop = type.GetProperty(name, BindingFlags.Instance | BindingFlags.Public);
-        if (prop != null) return prop.GetValue(instance);
-
-        return null;
+        if (!_memberCache.TryGetValue(name, out var member))
+        {
+            member = (MemberInfo?)type.GetField(name, BindingFlags.Instance | BindingFlags.Public)
+                  ?? (MemberInfo?)type.GetProperty(name, BindingFlags.Instance | BindingFlags.Public);
+            _memberCache[name] = member;
+        }
+        return member switch
+        {
+            FieldInfo f => f.GetValue(instance),
+            PropertyInfo p => p.GetValue(instance),
+            _ => null,
+        };
     }
 }

--- a/Helper/PlayerDataPoller.cs
+++ b/Helper/PlayerDataPoller.cs
@@ -22,6 +22,7 @@ internal class PlayerDataPoller : MonoBehaviour
     private readonly HashSet<string> _trackedInts = new();
     private readonly HashSet<string> _trackedCollectables = new();
     private readonly Dictionary<string, int> _collectableSnapshot = new();
+    private object? _lastPdRef;
 
     private const float PollIntervalSeconds = 0.5f;
 
@@ -71,6 +72,14 @@ internal class PlayerDataPoller : MonoBehaviour
             if (!PlayerData.HasInstance) continue;
             var pd = PlayerData.instance;
             var pdType = pd.GetType();
+
+            // New save loaded: PD instance flipped, drop stale baselines.
+            if (!ReferenceEquals(pd, _lastPdRef))
+            {
+                _snapshot.Clear();
+                _collectableSnapshot.Clear();
+                _lastPdRef = pd;
+            }
 
             foreach (var fieldName in _trackedBools)
             {

--- a/Helper/PlayerDataPoller.cs
+++ b/Helper/PlayerDataPoller.cs
@@ -41,6 +41,9 @@ internal class PlayerDataPoller : MonoBehaviour
         _trackedBools.Add(fieldName);
     }
 
+    // Most PD int writes now route through Harmony patches on SetInt/IncrementInt/IntAdd/DecrementInt.
+    // The int list here is the residue: fields written by direct field assignment in compiled game
+    // code that bypasses every typed setter. The dedup guard in BuzzOnPickups handles overlap.
     public void TrackInt(string fieldName)
     {
         _trackedInts.Add(fieldName);

--- a/ModHooks.cs
+++ b/ModHooks.cs
@@ -236,4 +236,16 @@ internal static class ModHooks
             OnItemPickupHook?.Invoke(__instance);
         }
     }
+
+    // Catches ALL PlayerData field writes via SetVariable (used by PlayerDataAccess properties)
+    // This is the universal hook for maps, abilities, tool pouch, silk heart, etc.
+    public static event Action<string, object>? OnPlayerDataSetVariableHook;
+    [HarmonyPatch(typeof(GenericVariableExtension.VariableExtensionsGeneric), nameof(GenericVariableExtension.VariableExtensionsGeneric.SetVariable),
+        new[] { typeof(object), typeof(string), typeof(object), typeof(Type) })]
+    [HarmonyPostfix]
+    private static void OnSetVariable(object obj, string fieldName, object value)
+    {
+        if (obj is PlayerData)
+            OnPlayerDataSetVariableHook?.Invoke(fieldName, value);
+    }
 }

--- a/ModHooks.cs
+++ b/ModHooks.cs
@@ -90,6 +90,7 @@ internal static class ModHooks
     [HarmonyPostfix]
     private static void OnSetBool(string boolName, bool value)
     {
+        if (value) _setVarLog.LogInfo($"[DIAG] PD.SetBool: {boolName} = {value}");
         OnSetBoolHook?.Invoke(boolName, value);
     }
 
@@ -98,8 +99,13 @@ internal static class ModHooks
     [HarmonyPostfix]
     private static void OnSetInt(string intName, int value)
     {
+        _setVarLog.LogInfo($"[DIAG] PD.SetInt: {intName} = {value}");
         OnSetIntHook?.Invoke(intName, value);
     }
+
+    // Called by PlayerDataPoller to fire the same events for fields written directly (bypass SetBool/SetInt)
+    internal static void RaiseSetBool(string name, bool value) => OnSetBoolHook?.Invoke(name, value);
+    internal static void RaiseSetInt(string name, int value) => OnSetIntHook?.Invoke(name, value);
 
     //Controller rumble
     public static event Action<string?>? OnRumbleHook;
@@ -203,11 +209,26 @@ internal static class ModHooks
         static IEnumerable<MethodBase> TargetMethods()
         {
             var methods = new List<MethodBase>();
+            var targetMethodNames = new[] { "Get", "Collect" };
 
-            var baseGet = typeof(SavedItem).GetMethod(nameof(SavedItem.Get), new[] { typeof(int), typeof(bool) });
-            if (baseGet != null && !baseGet.IsAbstract)
-                methods.Add(baseGet);
+            // Patch base SavedItem methods
+            foreach (var methodName in targetMethodNames)
+            {
+                var baseMethod2 = typeof(SavedItem).GetMethod(methodName, new[] { typeof(int), typeof(bool) });
+                if (baseMethod2 != null && !baseMethod2.IsAbstract)
+                    methods.Add(baseMethod2);
 
+                var baseMethod1 = typeof(SavedItem).GetMethod(methodName, new[] { typeof(bool) });
+                if (baseMethod1 != null && !baseMethod1.IsAbstract)
+                    methods.Add(baseMethod1);
+
+                // No-arg overload
+                var baseMethod0 = typeof(SavedItem).GetMethod(methodName, Type.EmptyTypes);
+                if (baseMethod0 != null && !baseMethod0.IsAbstract)
+                    methods.Add(baseMethod0);
+            }
+
+            // Scan all SavedItem subtypes for declared Get/Collect overrides
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
                 Type[] types;
@@ -222,11 +243,18 @@ internal static class ModHooks
 
                     foreach (var method in type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly))
                     {
-                        if (method.Name == nameof(SavedItem.Get) && !method.IsAbstract)
+                        if (targetMethodNames.Contains(method.Name) && !method.IsAbstract)
                             methods.Add(method);
                     }
                 }
             }
+
+            // Deduplicate (same method from base class could be added twice)
+            methods = methods.Distinct().ToList();
+
+            foreach (var m in methods)
+                log.LogInfo($"SavedItemGetPatch target: {m.DeclaringType.Name}.{m.Name}({string.Join(", ", m.GetParameters().Select(p => p.ParameterType.Name))})");
+
             return methods;
         }
 
@@ -240,12 +268,59 @@ internal static class ModHooks
     // Catches ALL PlayerData field writes via SetVariable (used by PlayerDataAccess properties)
     // This is the universal hook for maps, abilities, tool pouch, silk heart, etc.
     public static event Action<string, object>? OnPlayerDataSetVariableHook;
-    [HarmonyPatch(typeof(GenericVariableExtension.VariableExtensionsGeneric), nameof(GenericVariableExtension.VariableExtensionsGeneric.SetVariable),
-        new[] { typeof(object), typeof(string), typeof(object), typeof(Type) })]
-    [HarmonyPostfix]
-    private static void OnSetVariable(object obj, string fieldName, object value)
+
+    // Manual patch - attribute-based fails because the decompiled class name
+    // (GenericVariableExtension.VariableExtensionsGeneric) differs from the runtime class
+    // (TeamCherry.SharedUtils.VariableExtensions) which lives in a separate DLL.
+    internal static void ApplySetVariablePatch(Harmony harmony)
     {
-        if (obj is PlayerData)
-            OnPlayerDataSetVariableHook?.Invoke(fieldName, value);
+        var log = BepInEx.Logging.Logger.CreateLogSource("ButtplugSong.SetVarPatch");
+        MethodInfo? target = null;
+
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            Type[] types;
+            try { types = assembly.GetTypes(); }
+            catch (ReflectionTypeLoadException ex) { types = ex.Types.Where(t => t != null).ToArray()!; }
+            catch { continue; }
+
+            foreach (var type in types)
+            {
+                var method = type.GetMethod("SetVariable",
+                    BindingFlags.Static | BindingFlags.Public,
+                    null,
+                    new[] { typeof(object), typeof(string), typeof(object), typeof(Type) },
+                    null);
+                if (method != null)
+                {
+                    target = method;
+                    log.LogInfo($"Found SetVariable: {type.FullName}::{method.Name} in {assembly.GetName().Name}");
+                    break;
+                }
+            }
+            if (target != null) break;
+        }
+
+        if (target == null)
+        {
+            log.LogWarning("Could not find SetVariable(object, string, object, Type) in any loaded assembly!");
+            return;
+        }
+
+        var postfix = typeof(ModHooks).GetMethod(nameof(OnSetVariablePostfix), BindingFlags.Static | BindingFlags.NonPublic);
+        harmony.Patch(target, postfix: new HarmonyMethod(postfix));
+        log.LogInfo("SetVariable patch applied successfully.");
+    }
+
+    private static readonly BepInEx.Logging.ManualLogSource _setVarLog = 
+        BepInEx.Logging.Logger.CreateLogSource("ButtplugSong.SetVar");
+
+    private static void OnSetVariablePostfix(object __0, string __1, object __2)
+    {
+        if (__0 is PlayerData)
+        {
+            _setVarLog.LogInfo($"PD.SetVariable: {__1} = {__2}");
+            OnPlayerDataSetVariableHook?.Invoke(__1, __2);
+        }
     }
 }

--- a/ModHooks.cs
+++ b/ModHooks.cs
@@ -90,7 +90,7 @@ internal static class ModHooks
     [HarmonyPostfix]
     private static void OnSetBool(string boolName, bool value)
     {
-        if (value) _setVarLog.LogInfo($"[DIAG] PD.SetBool: {boolName} = {value}");
+        if (value) _setVarLog.LogDebug($"PD.SetBool: {boolName} = {value}");
         OnSetBoolHook?.Invoke(boolName, value);
     }
 
@@ -99,7 +99,7 @@ internal static class ModHooks
     [HarmonyPostfix]
     private static void OnSetInt(string intName, int value)
     {
-        _setVarLog.LogInfo($"[DIAG] PD.SetInt: {intName} = {value}");
+        _setVarLog.LogDebug($"PD.SetInt: {intName} = {value}");
         OnSetIntHook?.Invoke(intName, value);
     }
 
@@ -252,9 +252,6 @@ internal static class ModHooks
             // Deduplicate (same method from base class could be added twice)
             methods = methods.Distinct().ToList();
 
-            foreach (var m in methods)
-                log.LogInfo($"SavedItemGetPatch target: {m.DeclaringType.Name}.{m.Name}({string.Join(", ", m.GetParameters().Select(p => p.ParameterType.Name))})");
-
             return methods;
         }
 
@@ -319,7 +316,7 @@ internal static class ModHooks
     {
         if (__0 is PlayerData)
         {
-            _setVarLog.LogInfo($"PD.SetVariable: {__1} = {__2}");
+            _setVarLog.LogDebug($"PD.SetVariable: {__1} = {__2}");
             OnPlayerDataSetVariableHook?.Invoke(__1, __2);
         }
     }

--- a/ModHooks.cs
+++ b/ModHooks.cs
@@ -103,6 +103,36 @@ internal static class ModHooks
         OnSetIntHook?.Invoke(intName, value);
     }
 
+    // IncrementInt/IntAdd/DecrementInt write the field directly via reflection without calling SetInt.
+    // PlayMaker's IncrementPlayerDataInt + PlayerDataIntAdd actions route through these, so
+    // hooking them here catches FSM-driven counter writes (mask shards, spool fragments, silk skills, etc).
+    [HarmonyPatch(typeof(PlayerData), nameof(PlayerData.IncrementInt))]
+    [HarmonyPostfix]
+    private static void OnIncrementInt(PlayerData __instance, string intName)
+    {
+        int v = __instance.GetInt(intName);
+        _setVarLog.LogDebug($"PD.IncrementInt: {intName} -> {v}");
+        OnSetIntHook?.Invoke(intName, v);
+    }
+
+    [HarmonyPatch(typeof(PlayerData), nameof(PlayerData.IntAdd))]
+    [HarmonyPostfix]
+    private static void OnIntAdd(PlayerData __instance, string intName)
+    {
+        int v = __instance.GetInt(intName);
+        _setVarLog.LogDebug($"PD.IntAdd: {intName} -> {v}");
+        OnSetIntHook?.Invoke(intName, v);
+    }
+
+    [HarmonyPatch(typeof(PlayerData), nameof(PlayerData.DecrementInt))]
+    [HarmonyPostfix]
+    private static void OnDecrementInt(PlayerData __instance, string intName)
+    {
+        int v = __instance.GetInt(intName);
+        _setVarLog.LogDebug($"PD.DecrementInt: {intName} -> {v}");
+        OnSetIntHook?.Invoke(intName, v);
+    }
+
     // Called by PlayerDataPoller to fire the same events for fields written directly (bypass SetBool/SetInt)
     internal static void RaiseSetBool(string name, bool value) => OnSetBoolHook?.Invoke(name, value);
     internal static void RaiseSetInt(string name, int value) => OnSetIntHook?.Invoke(name, value);


### PR DESCRIPTION
  - Patch IncrementInt, IntAdd, DecrementInt on PlayerData. Catches
    FSM-driven counter writes that bypass SetInt.
  - Patch the static SetVariable(object, string, object, Type) helper
    PlayerDataAccess routes through. Resolved by signature scan once at
    startup.
  - SavedItemGetPatch now covers Get and Collect. Dedup guard kills the
    picked-up-tools double-trigger.
  - PlayerDataPoller for the residue: ~80 named fields plus
    CollectableItemManager (Mossberry). Half-second cadence,
    monotonic-increase trigger.
 
 
  - mossberry / quest items: poller.
  - tool pouch, silk heart, crests: IncrementInt + SetVariable.
  - silk skills, maps, pins, station unlocks: SetVariable.
  - silk spool fragment / mask shard: PR #17 plus IncrementInt belt.
  - tool double-trigger: SavedItemGetPatch dedup.